### PR TITLE
[feat] 채용지도 화면 지도 마커 기준 리스트 보여주기 (kan-10)

### DIFF
--- a/src/components/map/JobPostMap.tsx
+++ b/src/components/map/JobPostMap.tsx
@@ -13,7 +13,7 @@ interface Coordinates {
 interface JobPostMapType {
   coordinates: Coordinates;
   jobPostData: JobPostListData[];
-  setSortedjobPostData?: React.Dispatch<
+  setSortedJobPostData?: React.Dispatch<
     React.SetStateAction<JobPostListData[]>
   >;
 }
@@ -21,13 +21,13 @@ interface JobPostMapType {
 const JobPostMap = ({
   coordinates,
   jobPostData,
-  setSortedjobPostData,
+  setSortedJobPostData,
 }: JobPostMapType) => {
   const mapRef = useRef<HTMLDivElement | null>(null);
   const { naver } = window;
   let map: naver.maps.Map;
   const [newMap, setNewMap] = useState<naver.maps.Map | null>(null);
-  const markerListRef = useRef<naver.maps.Marker[]>([]); // 마커를 담을 배열을 useRef로 관리
+  const markerListRef = useRef<naver.maps.Marker[]>([]);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
 
   const navigate = useNavigate();
@@ -123,7 +123,8 @@ const JobPostMap = ({
         },
       });
       newMarker.setTitle(title);
-      markerListRef.current.push(newMarker); // 마커를 배열에 추가
+      markerListRef.current.push(newMarker);
+
       naver.maps.Event.addListener(newMarker, "click", () =>
         markerClickHandler(id)
       );
@@ -139,19 +140,28 @@ const JobPostMap = ({
     if (!map) return;
 
     const mapBounds = map.getBounds();
-    let marker: naver.maps.Marker, position;
+    let visibleJobPosts: JobPostListData[] = [];
 
-    // 마커의 위치를 position 변수에 저장
+    // let marker: naver.maps.Marker, position;
+
     for (let i = 0; i < markers.length; i++) {
-      marker = markers[i];
-      position = marker.getPosition();
+      const marker = markers[i];
+      const position = marker.getPosition();
 
-      // mapBounds와 비교하며 마커가 현재 화면에 보이는 영역에 있는지 확인
       if (mapBounds.hasPoint(position)) {
         showMarker(map, marker);
+
+        const jobPost = jobPostData.find(
+          (post) =>
+            post.latitude === position.y && post.longitude === position.x
+        );
+        if (jobPost) visibleJobPosts.push(jobPost);
       } else {
         hideMarker(marker);
       }
+    }
+    if (setSortedJobPostData) {
+      setSortedJobPostData(visibleJobPosts);
     }
   };
 


### PR DESCRIPTION
Motivation:
-  지도에 나와있는 마커 기준 채용정보 리스트 제공하도록 수정

Modification:
- 'JobPostMap.tsx' setSortedJobPostData를 프롭스 추가하여 마커와 같은 좌표면 배열에 push
- 'JobPostMapPage.tsx' initialCoordinates를 상태로 관리하도록 변경, api에서 받아온 latitude, longitude 숫자로 변환하여 관리